### PR TITLE
Fix "timeStamp" JSON property

### DIFF
--- a/app/src/main/java/com/tormentaLabs/riobus/marker/model/BusModel.java
+++ b/app/src/main/java/com/tormentaLabs/riobus/marker/model/BusModel.java
@@ -33,7 +33,7 @@ public class BusModel {
     @JsonProperty("sense")
     private String sense;
 
-    @JsonProperty("timestamp")
+    @JsonProperty("timeStamp")
     private String timeStamp;
 
     public BusModel() {


### PR DESCRIPTION
Correct is "timeStamp" instead of "timestamp":
https://github.com/RioBus/proxy/wiki/REST-API