### PR TITLE
Remove checkable property from the drawer menu

### DIFF
--- a/app/src/main/res/menu/rio_bus_activty.xml
+++ b/app/src/main/res/menu/rio_bus_activty.xml
@@ -3,18 +3,21 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="com.tormentaLabs.riobus.RioBusActivty">
 
-    <group android:checkableBehavior="single">
+    <group android:checkableBehavior="none">
         <!--<item android:id="@+id/action_settings" android:title="@string/menu_settings"
             android:checkable="true" android:icon="@drawable/ic_settings"
             app:showAsAction="withText|ifRoom" /> -->
         <item android:id="@+id/action_favorite" android:title="@string/menu_favorite"
-            android:checkable="true" android:icon="@drawable/ic_favorite" app:showAsAction="withText|ifRoom"/>
+            android:checkable="false" android:icon="@drawable/ic_favorite"
+            app:showAsAction="withText|ifRoom"/>
         <item android:id="@+id/action_history" android:title="@string/menu_history"
-            android:checkable="true" android:icon="@drawable/ic_history" app:showAsAction="withText|ifRoom"/>
-        <item android:id="@+id/action_about" android:title="@string/menu_about" android:checkable="true"
-            android:icon="@drawable/ic_help" app:showAsAction="withText|ifRoom"/>
+            android:checkable="false" android:icon="@drawable/ic_history"
+            app:showAsAction="withText|ifRoom"/>
+        <item android:id="@+id/action_about" android:title="@string/menu_about"
+            android:checkable="false" android:icon="@drawable/ic_help"
+            app:showAsAction="withText|ifRoom"/>
         <item android:id="@+id/action_rate_this_app" android:title="@string/menu_rate_this_app"
-            android:checkable="true" android:icon="@drawable/ic_thumb_up"
+            android:checkable="false" android:icon="@drawable/ic_thumb_up"
             app:showAsAction="withText|ifRoom" />
     </group>
 </menu>


### PR DESCRIPTION
The items on the Drawer Menu were still selected even after going back
to the main activity, now there will be no selected indicator to keep ir
cleaner and less confusing.